### PR TITLE
Remove sudo call

### DIFF
--- a/Network/Nmcli.hs
+++ b/Network/Nmcli.hs
@@ -31,8 +31,8 @@ knownCmd = Scan "nmcli --terse --fields name con list"
 
 -- | Given a wifi, execute the command to connect to a wifi (need super power :)
 conCmd :: Command
-conCmd = Connect ("sudo nmcli con up id " ++)
+conCmd = Connect ("nmcli con up id " ++)
 
 -- | Given a wifi, execute the creation of a new wifi entry
 createCmd :: Command
-createCmd = Create ( \ ssid psk -> "sudo nmcli dev wifi connect " ++ ssid ++ " password " ++ psk )
+createCmd = Create (\ ssid psk -> "nmcli dev wifi connect " ++ ssid ++ " password " ++ psk)


### PR DESCRIPTION
The user can either setup his/her environment or either wrap the `hwifi` call using sudo